### PR TITLE
Single-step Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Reproducible Python Package Creator
 `rppc` provides a command line interface for creating a skeleton for a reproducible python package. The package structure here follow the standards and conventions of much of the scientific Python eco-system. With these standards and recommendations, others will be able to use your code, port your code into other projects, and collaborate with other users.
 
 The package created tries to follow University of Washington eScience Institute [Guidelines for Reproducible and Open Science](http://uwescience.github.io/reproducible/guidelines.html).
+
+## 2 Factor Authentication
+
+Note that `git` CLI commands only accept basic authentication procedures. If you have 2FA set up on your account, you have to generate a [Personal Access Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/). In this case, when you are asked to enter a password in a manner such as:
+
+`Enter the GitHub password for <user_name>`:
+
+You have to enter your access token instead of your own password.

--- a/rppc/utils.py
+++ b/rppc/utils.py
@@ -1,18 +1,22 @@
 import os
 import requests
+import subprocess
 import warnings
 
+
 GITHUB_API_URL = 'https://api.github.com'
+
 
 def file_writer(folder, filename, content):
     with open(os.path.join(folder, filename), 'w') as f:
         f.write(content)
 
+
 def folder_creator(base_dir, folder_name):
     new_folder = os.path.join(base_dir, folder_name)
     if not os.path.exists(new_folder):
         os.mkdir(new_folder)
-    
+
     return new_folder
 
 
@@ -60,6 +64,7 @@ def check_package(package_name, github_username):
             warnings.warn(f'{package_name} exists on {github_username} Github account!')
             return r
 
+
 def create_repo(package_name, package_description, github_auth):
     try:
         github_username = github_auth['auth'].username
@@ -82,3 +87,12 @@ def create_repo(package_name, package_description, github_auth):
                 return Exception(req.text)
     except Exception as e:
         print(e)
+
+
+def make_command(command_list):
+    return ' '.join(command_list)
+
+
+def run_shell_command(command_list):
+    cmd = make_command(command_list)
+    subprocess.run(cmd, shell=True)


### PR DESCRIPTION
## Overview

Implemented single-step authentication by using `git config credential.helper`.

### Demo

```bash
(adrian_venv_3) ✘-1 ~/personal_projects/rppc [single-auth|✚ 2]
22:32 $ rppc init -f tests/package.yml -gh
0: BSD 2-Clause "Simplified" License
1: GNU General Public License v3.0
2: GNU Lesser General Public License v3.0
3: GNU Lesser General Public License v2.1
4: GNU Affero General Public License v3.0
5: Mozilla Public License 2.0
6: BSD 3-Clause "New" or "Revised" License
7: Apache License 2.0
8: The Unlicense
9: MIT License
10: Eclipse Public License 2.0
11: GNU General Public License v2.0
Select number: 0
What is your GitHub username? map34
Enter the GitHub password for map34:
Initialized empty Git repository in /Users/map34/personal_projects/rppc/MyAwesomePackage/.git/
versioneer.py (0.18) installed into local tree
Now running 'versioneer.py setup' to install the generated files..
versioneer.py:342: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  parser = configparser.SafeConfigParser()
versioneer.py:344: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
  parser.readfp(f)
 creating MyAwesomePackage/_version.py
 appending to MyAwesomePackage/__init__.py
 appending 'versioneer.py' to MANIFEST.in
 appending versionfile_source ('MyAwesomePackage/_version.py') to MANIFEST.in
Finished: An initial directory structure has been created.
You should now populate your master file /Users/map34/personal_projects/rppc/MyAwesomePackage/docs/source/index.rst and create other documentation
source files. Use the Makefile to build the docs, like so:
   make builder
where "builder" is one of the supported builders, e.g. html, latex or linkcheck.
[master (root-commit) 0fff38c] Initialize package repository
 23 files changed, 2933 insertions(+)
 create mode 100644 .flake8
 create mode 100644 .gitattributes
 create mode 100644 .gitignore
 create mode 100644 .travis.yml
 create mode 100644 AUTHORS.md
 create mode 100644 CONTRIBUTING.md
 create mode 100644 LICENSE
 create mode 100644 MANIFEST.in
 create mode 100644 MyAwesomePackage/__init__.py
 create mode 100644 MyAwesomePackage/_version.py
 create mode 100644 README.md
 create mode 100644 docs/Makefile
 create mode 100644 docs/make.bat
 create mode 100644 docs/source/conf.py
 create mode 100644 docs/source/index.rst
 create mode 100644 notebooks/.gitkeep
 create mode 100644 requirements-dev.txt
 create mode 100644 requirements.txt
 create mode 100644 setup.cfg
 create mode 100644 setup.py
 create mode 100644 tests/__init__.py
 create mode 100644 tests/test_example.py
 create mode 100644 versioneer.py
Setting local repo credentials...
Counting objects: 29, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (25/25), done.
Writing objects: 100% (29/29), 24.19 KiB | 2.20 MiB/s, done.
Total 29 (delta 1), reused 0 (delta 0)
remote: Resolving deltas: 100% (1/1), done.
remote:
remote: Create a pull request for 'master' on GitHub by visiting:
remote:      https://github.com/map34/MyAwesomePackage/pull/new/master
remote:
To https://github.com/map34/MyAwesomePackage.git
 * [new branch]      master -> master
Unsetting local repo credentials...
```

### Testing

Run `rppc init -f tests/package.yml -gh`