### PR TITLE
Escape (') character on description.

### DIFF
--- a/rppc/__init__.py
+++ b/rppc/__init__.py
@@ -80,6 +80,7 @@ def create_license(selection, package_dir, author_name):
 
 def create_setup(package_dir, package_name, package_description,
                 author_name, author_email, license_detail):
+    package_description = package_description.replace("'", "\\'")
     file_writer(package_dir,
                 'setup.py',
                 setup_template(

--- a/tests/package.yml
+++ b/tests/package.yml
@@ -1,5 +1,5 @@
 name: MyAwesomePackage
-description: This is my test package description
+description: This is my test's package description
 author: 
   name: John Smith
   email: jsmith@example.com


### PR DESCRIPTION
## Overview

This PR, automatically escapes the `'` character from package descriptions.

It resolves #11.